### PR TITLE
Adjust Marshal/Unmarshal Interface

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/spf13/cobra v1.8.1
 )
 
+replace github.com/JFryy/qq/codec => ../codec
+
 require (
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,13 +3,11 @@ module github.com/JFryy/qq/cli
 go 1.22.4
 
 require (
-	github.com/JFryy/qq/codec v0.0.0-20240626033059-fa396add9f28
-	github.com/JFryy/qq/internal/tui v0.0.0-20240626033059-fa396add9f28
+	github.com/JFryy/qq/codec v0.0.0-20240630034221-c0ecc1532bb6
+	github.com/JFryy/qq/internal/tui v0.0.0-20240630034221-c0ecc1532bb6
 	github.com/itchyny/gojq v0.12.16
 	github.com/spf13/cobra v1.8.1
 )
-
-replace github.com/JFryy/qq/codec => ../codec
 
 require (
 	github.com/BurntSushi/toml v1.4.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,7 +1,5 @@
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/JFryy/qq/codec v0.0.0-20240626033059-fa396add9f28 h1:wFbe/0NS0RsHEShjuOc2qfFvY0Mb4SfANCtNYxMihz4=
-github.com/JFryy/qq/codec v0.0.0-20240626033059-fa396add9f28/go.mod h1:1EK/NkTX3kh8uY6dA/ab5fmntXTSrtK9n6Oh6FNV0DI=
 github.com/JFryy/qq/internal/tui v0.0.0-20240626033059-fa396add9f28 h1:Ig16cOuxRBhmMKKgg8zge3DaXku9IXiBcBSHO5r3D+A=
 github.com/JFryy/qq/internal/tui v0.0.0-20240626033059-fa396add9f28/go.mod h1:Ly+dYmqoafiYbHisN05H7rfQPpMoW095T7ymfF1njes=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=

--- a/cli/qq.go
+++ b/cli/qq.go
@@ -112,8 +112,8 @@ func handleCommand(args []string, inputtype string, outputtype string, rawInput 
 		fmt.Println(err)
 		os.Exit(1)
 	}
-
-	data, err := codec.Unmarshal(input, inputCodec)
+	var data interface{}
+	err = codec.Unmarshal(input, inputCodec, &data)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -135,7 +135,8 @@ func handleCommand(args []string, inputtype string, outputtype string, rawInput 
 		os.Exit(0)
 	}
 
-	s, err := codec.Marshal(data, outputCodec)
+	b, err := codec.Marshal(data, outputCodec)
+	s := string(b)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -183,7 +184,8 @@ func executeQuery(query *gojq.Query, data interface{}, fileType codec.EncodingTy
 			fmt.Printf("Error executing jq expression: %v\n", err)
 			os.Exit(1)
 		}
-		s, err := codec.Marshal(v, fileType)
+		b, err := codec.Marshal(v, fileType)
+		s := string(b)
 		if err != nil {
 			fmt.Printf("Error formatting result: %v\n", err)
 			os.Exit(1)

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -61,29 +61,29 @@ var SupportedFileTypes = []Encoding{
 	{GRON, gronUnmarshal, gronMarshal},
 }
 
-func Unmarshal(input []byte, inputFileType EncodingType) (interface{}, error) {
+func Unmarshal(input []byte, inputFileType EncodingType, data interface{}) error {
 	for _, t := range SupportedFileTypes {
 		if t.Ext == inputFileType {
-			var data interface{}
-			err := t.Unmarshal(input, &data)
+			err := t.Unmarshal(input, data)
 			if err != nil {
-				return nil, fmt.Errorf("error parsing input: %v", err)
+				return fmt.Errorf("error parsing input: %v", err)
 			}
-			return data, nil
+			return nil
 		}
 	}
-	return nil, fmt.Errorf("unsupported input file type: %v", inputFileType)
+	return fmt.Errorf("unsupported input file type: %v", inputFileType)
 }
 
-func Marshal(v interface{}, outputFileType EncodingType) (string, error) {
+func Marshal(v interface{}, outputFileType EncodingType) ([]byte, error) {
 	for _, t := range SupportedFileTypes {
 		if t.Ext == outputFileType {
-			o, err := t.Marshal(v)
+			var err error
+			b, err := t.Marshal(v)
 			if err != nil {
-				return "", fmt.Errorf("error marshaling result to %s: %v", outputFileType, err)
+				return b, fmt.Errorf("error marshaling result to %s: %v", outputFileType, err)
 			}
-			return string(o), nil
+			return b, nil
 		}
 	}
-	return "", fmt.Errorf("unsupported output file type: %v", outputFileType)
+	return nil, fmt.Errorf("unsupported output file type: %v", outputFileType)
 }

--- a/codec/utils.go
+++ b/codec/utils.go
@@ -14,7 +14,8 @@ import (
 
 func PrettyFormat(s string, fileType EncodingType, raw bool) (string, error) {
 	if raw {
-		v, err := Unmarshal([]byte(s), fileType)
+		var v interface{}
+		err := Unmarshal([]byte(s), fileType, &v)
 		if err != nil {
 			return "", err
 		}
@@ -37,9 +38,9 @@ func PrettyFormat(s string, fileType EncodingType, raw bool) (string, error) {
 		lexer = lexers.Get("json")
 	} else {
 		lexer = lexers.Get(fileType.String())
-        if lexer == nil {
-            lexer = lexers.Fallback
-        }
+		if lexer == nil {
+			lexer = lexers.Fallback
+		}
 	}
 
 	if lexer == nil {

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,6 @@ require (
 	github.com/JFryy/qq/codec v0.0.0-20240630034221-c0ecc1532bb6
 )
 
-replace github.com/JFryy/qq/cli => ./cli
-
-replace github.com/JFryy/qq/codec => ./codec
-
 require (
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/JFryy/qq/internal/tui v0.0.0-20240630034221-c0ecc1532bb6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,17 @@ module github.com/JFryy/qq
 go 1.22.4
 
 require (
-	github.com/JFryy/qq/cli v0.0.0-20240627042830-6fe5404ea6a8
-	github.com/JFryy/qq/codec v0.0.0-20240627042830-6fe5404ea6a8
+	github.com/JFryy/qq/cli v0.0.0-20240630034221-c0ecc1532bb6
+	github.com/JFryy/qq/codec v0.0.0-20240630034221-c0ecc1532bb6
 )
+
+replace github.com/JFryy/qq/cli => ./cli
+
+replace github.com/JFryy/qq/codec => ./codec
 
 require (
 	github.com/BurntSushi/toml v1.4.0 // indirect
-	github.com/JFryy/qq/internal/tui v0.0.0-20240627042830-6fe5404ea6a8 // indirect
+	github.com/JFryy/qq/internal/tui v0.0.0-20240630034221-c0ecc1532bb6 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,15 +1,7 @@
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/JFryy/qq/cli v0.0.0-20240627035713-ff503872a7e0 h1:nuyiJKhBneH5IBSnqDjBdZ7sQlFf/GmPizHra3pMBCk=
-github.com/JFryy/qq/cli v0.0.0-20240627035713-ff503872a7e0/go.mod h1:ywdiLFS8L7py5K4/WJKC2XM+jKdi0ZWV7EpYQUCcsNA=
-github.com/JFryy/qq/cli v0.0.0-20240627042830-6fe5404ea6a8 h1:ipxPLiudDj+1JtlhsguSVFRxtDKRuEtYw3FZkK0dUww=
-github.com/JFryy/qq/cli v0.0.0-20240627042830-6fe5404ea6a8/go.mod h1:ywdiLFS8L7py5K4/WJKC2XM+jKdi0ZWV7EpYQUCcsNA=
-github.com/JFryy/qq/codec v0.0.0-20240627042830-6fe5404ea6a8 h1:RHVR84BWg5BlCDpderLwd+MUJAnxAPg9OPI3bmeSvO0=
-github.com/JFryy/qq/codec v0.0.0-20240627042830-6fe5404ea6a8/go.mod h1:zyrT0cJAPIt4HJkILVEox0xZD6LXggXWi2mg2zTqL+Q=
-github.com/JFryy/qq/internal/tui v0.0.0-20240627035713-ff503872a7e0 h1:N5IUaND0XRHpWVOMlvcJpP7LwR63iEF0cme/MiR7kQs=
-github.com/JFryy/qq/internal/tui v0.0.0-20240627035713-ff503872a7e0/go.mod h1:f3DEyNUYKn2WimPPqj09+ntPImdkzUHErm2i7PU2bHw=
-github.com/JFryy/qq/internal/tui v0.0.0-20240627042830-6fe5404ea6a8 h1:MZ0pVirwFqURYJGhZtTLKl3vennLZuhSh5q3RUas1fU=
-github.com/JFryy/qq/internal/tui v0.0.0-20240627042830-6fe5404ea6a8/go.mod h1:f3DEyNUYKn2WimPPqj09+ntPImdkzUHErm2i7PU2bHw=
+github.com/JFryy/qq/internal/tui v0.0.0-20240630034221-c0ecc1532bb6 h1:8UXgcefuk+tciSJOaAYmeXxyGO7hhshC8XNXqjvDQ1k=
+github.com/JFryy/qq/internal/tui v0.0.0-20240630034221-c0ecc1532bb6/go.mod h1:f3DEyNUYKn2WimPPqj09+ntPImdkzUHErm2i7PU2bHw=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/JFryy/qq/cli v0.0.0-20240630034221-c0ecc1532bb6 h1:XbdSv+UqhnORIc3PgtxNxhmEIHReHP3B+PgpEsoV/eU=
+github.com/JFryy/qq/cli v0.0.0-20240630034221-c0ecc1532bb6/go.mod h1:ywdiLFS8L7py5K4/WJKC2XM+jKdi0ZWV7EpYQUCcsNA=
+github.com/JFryy/qq/codec v0.0.0-20240630034221-c0ecc1532bb6 h1:hME5l/TBm63tkMlmgqP2FE+ng0PhQpAqaZytX7u+4YI=
+github.com/JFryy/qq/codec v0.0.0-20240630034221-c0ecc1532bb6/go.mod h1:zyrT0cJAPIt4HJkILVEox0xZD6LXggXWi2mg2zTqL+Q=
 github.com/JFryy/qq/internal/tui v0.0.0-20240630034221-c0ecc1532bb6 h1:8UXgcefuk+tciSJOaAYmeXxyGO7hhshC8XNXqjvDQ1k=
 github.com/JFryy/qq/internal/tui v0.0.0-20240630034221-c0ecc1532bb6/go.mod h1:f3DEyNUYKn2WimPPqj09+ntPImdkzUHErm2i7PU2bHw=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=


### PR DESCRIPTION
## Description
Previously the Unmarshal function wrapper for the codec was passing interface directly not as a reference which was a bit non-standard and would cause a bit overhead. Also the marshal wrapper had the issue of returning a string, which could cause the need of additional conversions in use-cases external to this cli tool. 



## Changes

- [X] **🛠️ Code Changes**
  - [ ] Implemented feature 
  - [ ] Fixed bug
  - [X] Refactored component 
  - [ ] Updated documentation

- [X] **🐛 Testing**
  - [ ] Added unit tests for new functionality
  - [ ] Updated existing tests to reflect changes
  - [X] Ran all tests locally

- [ ] **📄 Documentation**
  - [ ] Updated README or documentation files as needed

## Additional Notes

