### PR TITLE
Improve HTML Processing Towards XML->Map Specification And Add Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,18 @@ Basic usage:
 # JSON is default in and output.
 cat file.${ext} | qq -i ${ext}
 
-# query xml, grep with gron using qq io (for example) - gron is great.
+# Extension is parsed, no need for input flag
+qq '.' file.xml
+
+# random example: query xml, grep with gron using qq io and output as json
 qq file.xml -o gron | grep -vE "sweet.potatoes" | qq -i gron
 
 # get some content from a site with html input
-curl motherfuckingwebsite.com | qq -i html '.html.body.ul[][].data'
+curl motherfuckingwebsite.com | bin/qq -i html '.html.body.ul.li[0]'
+
 
 # interactive query builder mode on target file
-qq . file.toml --interactive
+qq . file.json --interactive
 ```
 
 ## Installation
@@ -103,6 +107,7 @@ Note: these unsupported formats are on a roadmap for inclusion.
 | CSV         | ✅ Supported   | ❌ Not Supported |
 | Protobuf    | ❌ Not Supported | ❌ Not Supported |
 | HTML        | ✅ Supported   | ❌ Not Supported |
+| TXT (newline)| ✅ Supported   | ❌ Not Supported |
 
 
 ## Caveats

--- a/cli/qq.go
+++ b/cli/qq.go
@@ -18,12 +18,18 @@ func CreateRootCmd() *cobra.Command {
 	var interactive bool
 	var version bool
 	var help bool
-	v := "v0.2.0"
-
+    var encodings string
+    for _, t := range codec.SupportedFileTypes {
+        encodings += t.Ext.String() + ", "
+    }
+    encodings = strings.TrimSuffix(encodings, ", ")
+	v := "v0.2.1"
+	desc := fmt.Sprintf("qq is a interoperable configuration format transcoder with jq querying ability powered by gojq. qq is multi modal, and can be used as a replacement for jq or be interacted with via a repl with autocomplete and realtime rendering preview for building queries. Supported formats include %s", encodings)
 	cmd := &cobra.Command{
 		Use:   "qq [expression] [file] [flags] \n  cat [file] | qq [expression] [flags] \n  qq -I file",
 		Short: "qq - JQ processing with conversions for popular configuration formats.",
-		Long:  "qq is a interoperable configuration format transcoder with jq querying ability powered by gojq. qq is multi modal, and can be used as a replacement for jq or be interacted with via a repl with autocomplete and realtime rendering preview for building queries.",
+
+		Long: desc,
 		Run: func(cmd *cobra.Command, args []string) {
 			if version {
 				fmt.Println("qq version", v)

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -23,10 +23,12 @@ const (
 	INI
 	GRON
 	HTML
+	LINE
+	TXT
 )
 
 func (e EncodingType) String() string {
-	return [...]string{"json", "yaml", "yml", "toml", "hcl", "tf", "csv", "xml", "ini", "gron", "html"}[e]
+	return [...]string{"json", "yaml", "yml", "toml", "hcl", "tf", "csv", "xml", "ini", "gron", "html", "line", "txt"}[e]
 }
 
 type Encoding struct {
@@ -61,6 +63,8 @@ var SupportedFileTypes = []Encoding{
 	{INI, iniUnmarshal, iniMarshal},
 	{GRON, gronUnmarshal, gronMarshal},
 	{HTML, htmlUnmarshal, jsonMarshalIndent},
+	{LINE, lineUnmarshal, jsonMarshalIndent},
+	{TXT, lineUnmarshal, jsonMarshalIndent},
 }
 
 func Unmarshal(input []byte, inputFileType EncodingType, data interface{}) error {

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1,0 +1,106 @@
+package codec
+
+import (
+	"testing"
+)
+
+func TestGetEncodingType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected EncodingType
+	}{
+		{"json", JSON},
+		{"yaml", YAML},
+		{"yml", YML},
+		{"toml", TOML},
+		{"hcl", HCL},
+		{"tf", TF},
+		{"csv", CSV},
+		{"xml", XML},
+		{"ini", INI},
+		{"gron", GRON},
+		{"html", HTML},
+	}
+
+	for _, tt := range tests {
+		result, err := GetEncodingType(tt.input)
+		if err != nil {
+			t.Errorf("unexpected error for type %s: %v", tt.input, err)
+		} else if result != tt.expected {
+			t.Errorf("expected %v, got %v", tt.expected, result)
+		}
+	}
+
+	unsupportedResult, err := GetEncodingType("unsupported")
+	if err == nil {
+		t.Errorf("expected error for unsupported type, got result: %v", unsupportedResult)
+	}
+}
+
+func TestMarshal(t *testing.T) {
+	data := map[string]interface{}{"key": "value"}
+	tests := []struct {
+		encodingType EncodingType
+	}{
+		{JSON}, {YAML}, {YML}, {TOML}, {HCL}, {TF}, {CSV}, {XML}, {INI}, {GRON}, {HTML},
+	}
+
+	for _, tt := range tests {
+		_, err := Marshal(data, tt.encodingType)
+		if err != nil {
+			t.Errorf("marshal failed for %v: %v", tt.encodingType, err)
+		}
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	jsonData := `{"key": "value"}`
+	xmlData := `<root><key>value</key></root>`
+	yamlData := "key: value"
+	tomlData := "key = \"value\""
+
+	tests := []struct {
+		input        []byte
+		encodingType EncodingType
+	}{
+		{[]byte(jsonData), JSON},
+		{[]byte(xmlData), XML},
+		{[]byte(yamlData), YAML},
+		{[]byte(tomlData), TOML},
+	}
+
+	for _, tt := range tests {
+		var data interface{} 
+		err := Unmarshal(tt.input, tt.encodingType, &data)
+		if err != nil {
+			t.Errorf("unmarshal failed for %v: %v", tt.encodingType, err)
+		}
+		
+		m, ok := data.(map[string]interface{})
+		if !ok {
+			t.Errorf("expected map[string]interface{}, got %T", data)
+		}
+		if value, ok := m["key"]; !ok || value != "value" {
+			t.Errorf("expected key 'key' with value 'value', got %v", data)
+		}
+	}
+}
+
+func TestUnsupportedTypes(t *testing.T) {
+	data := map[string]interface{}{"key": "value"}
+
+	
+	unsupportedType := EncodingType(len(SupportedFileTypes) + 1)
+	_, err := Marshal(data, unsupportedType)
+	if err == nil {
+		t.Error("expected error for unsupported marshal type, got nil")
+	}
+
+	
+	unsupportedData := []byte(`{"key": "value"}`)
+	err = Unmarshal(unsupportedData, unsupportedType, &data)
+	if err == nil {
+		t.Error("expected error for unsupported unmarshal type, got nil")
+	}
+}
+

--- a/codec/csv_codec.go
+++ b/codec/csv_codec.go
@@ -16,21 +16,19 @@ func csvUnmarshal(input []byte, v interface{}) error {
 		return fmt.Errorf("error reading CSV headers: %v", err)
 	}
 
-	var records [][]string
-
-	// Append headers as the first record
-	records = append(records, headers)
-
-	// Read the remaining rows
+	var records []map[string]string
 	for {
 		record, err := r.Read()
 		if err != nil {
 			break
 		}
-		records = append(records, record)
-	}
 
-	// Marshal the records to JSON and then unmarshal into the provided interface
+		rowMap := make(map[string]string)
+		for i, header := range headers {
+			rowMap[header] = record[i]
+		}
+		records = append(records, rowMap)
+	}
 	jsonData, err := json.Marshal(records)
 	if err != nil {
 		return fmt.Errorf("error marshaling to JSON: %v", err)

--- a/codec/html.go
+++ b/codec/html.go
@@ -8,7 +8,7 @@ import (
 )
 
 /*
-HTML to Map Converter. These functions do not yet cover conversion to HTML, only from HTML to other arbitary output formats at this time.
+HTML to Map Converter. These functions do not yet cover conversion to HTML, only from HTML to other arbitrary output formats at this time.
 This implementation may have some limitations and may not cover all edge cases.
 */
 
@@ -29,47 +29,86 @@ func HTMLToMap(htmlBytes []byte) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return nodeToMap(doc), nil
-}
 
-func nodeToMap(node *html.Node) map[string]interface{} {
-	// handle text node edge cases
-	if node.Type == html.TextNode {
-		text := strings.TrimSpace(node.Data)
-		if text != "" {
-			if strings.TrimSpace(text) == "" && strings.ContainsAny(text, "\n\r") {
-				return nil
-			}
-			return map[string]interface{}{"data": node.Data}
+	// Always handle presence of root html node
+	var root *html.Node
+	for node := doc.FirstChild; node != nil; node = node.NextSibling {
+		if node.Type == html.ElementNode && node.Data == "html" {
+			root = node
+			break
 		}
 	}
 
-	// map initialization
+	if root == nil {
+		return nil, nil
+	}
+
+	result := nodeToMap(root)
+	if m, ok := result.(map[string]interface{}); ok {
+		return map[string]interface{}{"html": m}, nil
+	}
+	return nil, nil
+}
+
+func nodeToMap(node *html.Node) interface{} {
+
+	// Handle text proceeding and following whitespace, newlines, etc.
+	if node.Type == html.TextNode {
+		text := strings.TrimSpace(node.Data)
+		if text == "" {
+			return nil
+		}
+		if strings.TrimSpace(text) == "" && strings.ContainsAny(text, "\n\r") {
+			return nil
+		}
+		text, _ = strings.CutSuffix(text, "\n\r")
+		text, _ = strings.CutPrefix(text, "\n")
+		return text
+	}
+
+	if node.Type == html.CommentNode {
+		text := strings.TrimSpace(node.Data)
+		if text == "" {
+			return nil
+		}
+		if strings.TrimSpace(text) == "" && strings.ContainsAny(text, "\n\r") {
+			return nil
+		}
+		text, _ = strings.CutSuffix(text, "\n\r")
+		text, _ = strings.CutPrefix(text, "\n")
+		return map[string]interface{}{"#comment": text}
+
+	}
+
 	m := make(map[string]interface{})
 
 	// Process attributes if present for node
 	if node.Attr != nil {
-		attrs := make(map[string]string)
 		for _, attr := range node.Attr {
-			attrs[attr.Key] = attr.Val
+			m["@"+attr.Key] = attr.Val
 		}
-		m["attr"] = attrs
 	}
 
 	// Recursively process children
+	var childTexts []string
+	var comments []string
 	children := make(map[string][]interface{})
 	for child := node.FirstChild; child != nil; child = child.NextSibling {
 		childMap := nodeToMap(child)
 		if childMap != nil {
 			if child.Type == html.ElementNode {
 				children[child.Data] = append(children[child.Data], childMap)
-			} else if data, ok := childMap["data"]; ok {
-				m["data"] = data
+			} else if text, ok := childMap.(string); ok {
+				childTexts = append(childTexts, text)
+			} else if comment, ok := childMap.(map[string]interface{}); ok && comment["#comment"] != nil {
+				if commentText, ok := comment["#comment"].(string); ok {
+					comments = append(comments, commentText)
+				}
 			}
 		}
 	}
 
-	// merge
+	// Merge children into map
 	for key, value := range children {
 		if len(value) == 1 {
 			m[key] = value[0]
@@ -78,8 +117,45 @@ func nodeToMap(node *html.Node) map[string]interface{} {
 		}
 	}
 
+	// Handle text content if present
+	if len(childTexts) > 0 {
+		if len(childTexts) == 1 {
+			if len(m) == 0 {
+				return childTexts[0]
+			}
+			m["#text"] = childTexts[0]
+		} else {
+			m["#text"] = strings.Join(childTexts, " ")
+		}
+	}
+
+	// Handle comments if present
+	if len(comments) > 0 {
+		if len(comments) == 1 {
+			if len(m) == 0 {
+				return map[string]interface{}{"#comment": comments[0]}
+			} else {
+				m["#comment"] = comments[0]
+			}
+		}
+	}
+
+	// Simplify map if only contains text or single child element
 	if len(m) == 0 {
 		return nil
+	} else if len(m) == 1 {
+		if text, ok := m["#text"]; ok {
+			return text
+		}
+		if len(node.Attr) == 0 {
+			for key, val := range m {
+				if childMap, ok := val.(map[string]interface{}); ok && len(childMap) == 1 {
+					return val
+				}
+				return map[string]interface{}{key: val}
+			}
+		}
 	}
 	return m
 }
+

--- a/codec/line_codec.go
+++ b/codec/line_codec.go
@@ -1,0 +1,23 @@
+package codec
+
+import (
+	"fmt"
+	"github.com/goccy/go-json"
+	"strings"
+)
+
+func lineUnmarshal(input []byte, v interface{}) error {
+	lines := strings.Split(strings.TrimSpace(string(input)), "\n")
+
+	// Marshal the lines to JSON and then unmarshal into the provided interface
+	jsonData, err := json.Marshal(lines)
+	if err != nil {
+		return fmt.Errorf("error marshaling to JSON: %v", err)
+	}
+
+	if err := json.Unmarshal(jsonData, v); err != nil {
+		return fmt.Errorf("error unmarshaling JSON: %v", err)
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/JFryy/qq
 
 go 1.22.4
+
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/alecthomas/chroma v0.10.0
@@ -12,12 +13,12 @@ require (
 	github.com/goccy/go-yaml v1.12.0
 	github.com/hashicorp/hcl/v2 v2.21.0
 	github.com/itchyny/gojq v0.12.16
+	github.com/mattn/go-isatty v0.0.20
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/cobra v1.8.1
 	github.com/tmccombs/hcl2json v0.6.3
 	github.com/zclconf/go-cty v1.15.0
 	golang.org/x/net v0.27.0
-	golang.org/x/sys v0.22.0
 	gopkg.in/ini.v1 v1.67.0
 )
 
@@ -27,7 +28,7 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/x/ansi v0.1.4 // indirect
-	github.com/charmbracelet/x/input v0.1.2 // indirect
+	github.com/charmbracelet/x/input v0.1.3 // indirect
 	github.com/charmbracelet/x/term v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.1.2 // indirect
 	github.com/dlclark/regexp2 v1.11.2 // indirect
@@ -38,9 +39,8 @@ require (
 	github.com/itchyny/timefmt-go v0.1.6 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
@@ -50,6 +50,7 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/tools v0.23.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240716161551-93cc26a95ae9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/charmbracelet/x/ansi v0.1.4 h1:IEU3D6+dWwPSgZ6HBH+v6oUuZ/nVawMiWj5831
 github.com/charmbracelet/x/ansi v0.1.4/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/charmbracelet/x/input v0.1.2 h1:QJAZr33eOhDowkkEQ24rsJy4Llxlm+fRDf/cQrmqJa0=
 github.com/charmbracelet/x/input v0.1.2/go.mod h1:LGBim0maUY4Pitjn/4fHnuXb4KirU3DODsyuHuXdOyA=
+github.com/charmbracelet/x/input v0.1.3 h1:oy4TMhyGQsYs/WWJwu1ELUMFnjiUAXwtDf048fHbCkg=
+github.com/charmbracelet/x/input v0.1.3/go.mod h1:1gaCOyw1KI9e2j00j/BBZ4ErzRZqa05w0Ghn83yIhKU=
 github.com/charmbracelet/x/term v0.1.1 h1:3cosVAiPOig+EV4X9U+3LDgtwwAoEzJjNdwbXDjF6yI=
 github.com/charmbracelet/x/term v0.1.1/go.mod h1:wB1fHt5ECsu3mXYusyzcngVWWlu1KKUmmLhfgr/Flxw=
 github.com/charmbracelet/x/windows v0.1.2 h1:Iumiwq2G+BRmgoayww/qfcvof7W/3uLoelhxojXlRWg=
@@ -72,6 +74,8 @@ github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2J
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -107,6 +111,7 @@ golang.org/x/crypto v0.25.0 h1:ypSNr+bnYL2YhwoMt2zPxHFmbAN1KZs/njMG3hxUp30=
 golang.org/x/crypto v0.25.0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=
 golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=

--- a/tests/test.csv
+++ b/tests/test.csv
@@ -1,5 +1,3 @@
-# .[1][1]
-# .[][2]
 name,age,email
 John Doe,29,john.doe@example.com
 Jane Smith,34,jane.smith@example.com

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -23,7 +23,8 @@ print() {
 }
 
 
-extensions=$(ls -1 tests/* | grep -Ev '.sh|csv')
+# ini has edge cases that prevent transcoding to other formats
+extensions=$(ls -1 tests/* | grep -Ev '.sh|ini')
 for i in ${extensions}; do
     echo "Testing $i"
     for f in ${extensions}; do

--- a/tests/test.txt
+++ b/tests/test.txt
@@ -1,0 +1,3 @@
+this is an example
+this is also another one
+this is one more


### PR DESCRIPTION
## Description
Tried this with a variety of sites for verifying correctness, will merge once unit tests complete and if anyone would like to give a review if nothing else (if you're not too opinionated on the implementation but rather the end result just to validate correctness).

 I've done some tests with fq and qq comparison, the only difference is some trimming of space trailing newlines and things of that nature and doesn't look harmful or massively inconvenient.

 ```shell
 ❯ export site=example.com  && curl $site | go run . -i html > qq_o.json && curl $site | fq > fq_o.json && diff qq_o.json fq_o.json

 ```



## Changes

- [x] **🛠️ Code Changes**
  - [x] Implemented feature 
  - [ ] Fixed bug
  - [ ] Refactored component 
  - [ ] Updated documentation

- [x] **🐛 Testing**
  - [x] Added unit tests for new functionality
  - [x] Updated existing tests to reflect changes
  - [x] Ran all tests locally

- [ ] **📄 Documentation**
  - [ ] Updated README or documentation files as needed

## Additional Notes

