### PR TITLE
fix yaml parser, stream mode parity with jq, SIGPIPE handling, version bump

### DIFF
--- a/cli/qq.go
+++ b/cli/qq.go
@@ -26,7 +26,7 @@ func CreateRootCmd() *cobra.Command {
 	var slurp bool
 	var exitStatus bool
 	encodings := strings.Join(codec.GetSupportedExtensions(), ", ")
-	v := "v0.3.3"
+	v := "v0.3.4"
 	desc := fmt.Sprintf("qq is a interoperable configuration format transcoder with jq querying ability powered by gojq. qq is multi modal, and can be used as a replacement for jq or be interacted with via a repl with autocomplete and realtime rendering preview for building queries. Supported formats include %s", encodings)
 	cmd := &cobra.Command{
 		Use:   "qq [expression] [file] [flags] \n  cat [file] | qq [expression] [flags] \n  qq -I file",
@@ -420,20 +420,14 @@ func executeStreamingQuery(query *gojq.Query, reader io.Reader, inputType codec.
 					os.Exit(1)
 				}
 
-				b, err := codec.Marshal(v, outputType)
+				// Stream elements are always emitted as compact JSON (one line
+				// per element), matching jq --stream behaviour regardless of -o.
+				b, err := json.Marshal(v)
 				if err != nil {
 					fmt.Printf("Error formatting result: %v\n", err)
 					os.Exit(1)
 				}
-
-				if codec.IsBinaryFormat(outputType) {
-					// For binary formats, write directly to stdout as raw bytes
-					os.Stdout.Write(b)
-				} else {
-					s := string(b)
-					r, _ := codec.PrettyFormat(s, outputType, rawOut, monochrome)
-					fmt.Println(r)
-				}
+				fmt.Println(string(b))
 			}
 
 		case err := <-errChan:

--- a/codec/stream.go
+++ b/codec/stream.go
@@ -319,10 +319,13 @@ func convertToStream(value any, basePath []any) []any {
 			path := append(append([]any{}, basePath...), key)
 			result = append(result, convertToStream(val, path)...)
 		}
-		// Emit closing marker
 		if hasKeys {
 			closePath := append(append([]any{}, basePath...), lastKey)
 			result = append(result, []any{closePath})
+		} else {
+			pathCopy := make([]any, len(basePath))
+			copy(pathCopy, basePath)
+			result = append(result, []any{pathCopy, map[string]any{}})
 		}
 
 	case []any:
@@ -332,10 +335,13 @@ func convertToStream(value any, basePath []any) []any {
 			path := append(append([]any{}, basePath...), i)
 			result = append(result, convertToStream(val, path)...)
 		}
-		// Emit closing marker
 		if lastIndex >= 0 {
 			closePath := append(append([]any{}, basePath...), lastIndex)
 			result = append(result, []any{closePath})
+		} else {
+			pathCopy := make([]any, len(basePath))
+			copy(pathCopy, basePath)
+			result = append(result, []any{pathCopy, []any{}})
 		}
 
 	default:
@@ -374,10 +380,14 @@ func parseStreamToChannel(decoder *json.Decoder, path []any, dataChan chan<- any
 			if _, err := decoder.Token(); err != nil {
 				return err
 			}
-			// Emit closing marker
 			if lastIndex >= 0 {
 				closePath := append(append([]any{}, path...), lastIndex)
 				dataChan <- []any{closePath}
+			} else {
+				// Empty array: jq emits [path, []]
+				pathCopy := make([]any, len(path))
+				copy(pathCopy, path)
+				dataChan <- []any{pathCopy, []any{}}
 			}
 			return nil
 
@@ -406,10 +416,14 @@ func parseStreamToChannel(decoder *json.Decoder, path []any, dataChan chan<- any
 			if _, err := decoder.Token(); err != nil {
 				return err
 			}
-			// Emit closing marker
 			if hasKeys {
 				closePath := append(append([]any{}, path...), lastKey)
 				dataChan <- []any{closePath}
+			} else {
+				// Empty object: jq emits [path, {}]
+				pathCopy := make([]any, len(path))
+				copy(pathCopy, path)
+				dataChan <- []any{pathCopy, map[string]any{}}
 			}
 			return nil
 

--- a/codec/yaml/yaml.go
+++ b/codec/yaml/yaml.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/goccy/go-yaml"
+	"go.yaml.in/yaml/v4"
 )
 
 type Codec struct{}
@@ -132,7 +132,7 @@ func (c Codec) Marshal(v any) ([]byte, error) {
 				buf.WriteString("---\n")
 
 				// Marshal the document
-				docBytes, err := yaml.Marshal(doc)
+				docBytes, err := marshalIndent(doc)
 				if err != nil {
 					return nil, err
 				}
@@ -143,5 +143,15 @@ func (c Codec) Marshal(v any) ([]byte, error) {
 	}
 
 	// For everything else, use standard YAML marshaling
-	return yaml.Marshal(v)
+	return marshalIndent(v)
+}
+
+func marshalIndent(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/codec/yaml/yaml_test.go
+++ b/codec/yaml/yaml_test.go
@@ -495,6 +495,29 @@ active: true`
 	}
 }
 
+func TestMultilineBlockScalarInSequence(t *testing.T) {
+	// Regression test: multiline plain scalar as a sequence item must parse
+	// identically to an equivalent block scalar (goccy/go-yaml rejected it).
+	yamlData := "key:\n  - dummy_args=(\n      --null-input\n    )\n"
+
+	codec := &Codec{}
+
+	var result any
+	err := codec.Unmarshal([]byte(yamlData), &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal multiline plain scalar: %v", err)
+	}
+
+	doc := result.(map[string]any)
+	items := doc["key"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("Expected 1 item, got %d", len(items))
+	}
+	if items[0] != "dummy_args=( --null-input )" {
+		t.Errorf("Expected 'dummy_args=( --null-input )', got %v", items[0])
+	}
+}
+
 func TestEmptyDocuments(t *testing.T) {
 	// Test handling of empty documents
 	multiDocYAML := `---

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/goccy/go-json v0.10.5
-	github.com/goccy/go-yaml v1.19.2
 	github.com/hamba/avro/v2 v2.31.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/itchyny/gojq v0.12.18
@@ -23,6 +22,7 @@ require (
 	github.com/tmccombs/hcl2json v0.6.8
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/zclconf/go-cty v1.18.0
+	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/net v0.51.0
 	gopkg.in/ini.v1 v1.67.1
 )

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPE
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
-github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
-github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
@@ -184,6 +182,8 @@ go.opentelemetry.io/otel/sdk/metric v1.39.0/go.mod h1:xq9HEVH7qeX69/JnwEfp6fVq5w
 go.opentelemetry.io/otel/trace v1.39.0 h1:2d2vfpEDmCJ5zVYz7ijaJdOF59xLomrvj7bjt6/qCJI=
 go.opentelemetry.io/otel/trace v1.39.0/go.mod h1:88w4/PnZSazkGzz/w84VHpQafiU4EtqqlVdxWy+rNOA=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+go.yaml.in/yaml/v4 v4.0.0-rc.4 h1:UP4+v6fFrBIb1l934bDl//mmnoIZEDK0idg1+AIvX5U=
+go.yaml.in/yaml/v4 v4.0.0-rc.4/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa h1:Zt3DZoOFFYkKhDT3v7Lm9FDMEV06GpzjG2jrqW+QTE0=
 golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa/go.mod h1:K79w1Vqn7PoiZn+TkNpx3BUWUQksGO3JcVX6qIjytmA=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=

--- a/main.go
+++ b/main.go
@@ -2,11 +2,31 @@ package main
 
 import (
 	"fmt"
-	"github.com/JFryy/qq/cli"
 	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/JFryy/qq/cli"
 )
 
 func main() {
+	// When qq is used in a pipeline and the downstream consumer exits early
+	// (e.g. `qq --stream ... | grep -q foo`), the OS sends SIGPIPE to qq the
+	// next time it writes to the now-closed pipe. Go's default behaviour is to
+	// let SIGPIPE kill the process, which produces exit code 141 (128+13) and
+	// causes shells running with `pipefail` to report a failure even though the
+	// pipeline did exactly what was asked of it.
+	//
+	// We catch SIGPIPE and exit 0 instead, matching the behaviour of standard
+	// Unix tools (grep, sed, head, etc.). The goroutine stops qq immediately
+	// rather than letting it drain the rest of its input with nowhere to write.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGPIPE)
+	go func() {
+		<-sigCh
+		os.Exit(0)
+	}()
+
 	rootCmd := cli.CreateRootCmd()
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Replace goccy/go-yaml with go.yaml.in/yaml/v4 (the actively maintained successor to the standard go yaml library), which correctly parses multiline plain scalars in sequences that goccy rejected with "value is not allowed in this context". Add a regression test for the failing case. Use SetIndent(2) on the encoder to preserve the existing 2-space indentation in YAML output.

Fix --stream output to match jq --stream exactly: emit one compact JSON line per element instead of pretty-printed blocks, and emit [path, []] / [path, {}] for empty arrays and objects (previously silently dropped).

Catch SIGPIPE and exit 0 so pipelines like `qq --stream | grep -q foo` don't report failure when the downstream consumer exits early


## Changes

- [X] **🛠️ Code Changes**
  - [X] Implemented feature 
  - [X] Fixed bug
  - [ ] Refactored component 
  - [X] Updated documentation

- [X] **🐛 Testing**
  - [X] Added unit tests for new functionality
  - [X] Updated existing tests to reflect changes
  - [X] Ran all tests locally

- [ ] **📄 Documentation**
  - [ ] Updated README or documentation files as needed

## Additional Notes

