### PR TITLE
feat: add --no-auto-convert flag to disable automatic type coercion of strings

### DIFF
--- a/cli/integration_test.go
+++ b/cli/integration_test.go
@@ -1,0 +1,252 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/JFryy/qq/codec"
+	"github.com/itchyny/gojq"
+)
+
+// runPipeline is an E2E helper that parses input, executes a JQ expression,
+// and captures the serialized output printed by executeQuery.
+func runPipeline(t *testing.T, input []byte, inputFormat codec.EncodingType, outputFormat codec.EncodingType, queryStr string, noAutoConvert bool, rawOut bool) (string, error) {
+	codec.SetDisableAutoConvert(noAutoConvert)
+	defer func() {
+		codec.SetDisableAutoConvert(false)
+	}()
+
+	var data any
+	if err := codec.Unmarshal(input, inputFormat, &data); err != nil {
+		return "", fmt.Errorf("unmarshal error: %w", err)
+	}
+
+	q, err := gojq.Parse(queryStr)
+	if err != nil {
+		return "", fmt.Errorf("query parse error: %w", err)
+	}
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	exitCode := executeQuery(q, data, outputFormat, rawOut, true, false)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	if exitCode != 0 {
+		return "", fmt.Errorf("exit code: %d, output: %s", exitCode, buf.String())
+	}
+
+	return buf.String(), nil
+}
+
+func TestE2E_Formats_JQExpressions(t *testing.T) {
+	// Test suite verifying each input format with various JQ expressions
+	tests := []struct {
+		name        string
+		input       []byte
+		inputFormat codec.EncodingType
+		query       string
+		expected    string
+	}{
+		// CSV Input
+		{
+			name:        "CSV identity",
+			input:       []byte("a,b,c\n1,2,3\n"),
+			inputFormat: codec.CSV,
+			query:       ".",
+			expected:    `[{"a":1,"b":2,"c":3}]`,
+		},
+		{
+			name:        "CSV array iteration",
+			input:       []byte("a,b,c\n1,2,3\n"),
+			inputFormat: codec.CSV,
+			query:       ".[]",
+			expected:    `{"a":1,"b":2,"c":3}`,
+		},
+		{
+			name:        "CSV length",
+			input:       []byte("a,b,c\n1,2,3\n"),
+			inputFormat: codec.CSV,
+			query:       "length",
+			expected:    `1`,
+		},
+		// TSV Input
+		{
+			name:        "TSV array index",
+			input:       []byte("a\tb\n1\t2\n"),
+			inputFormat: codec.TSV,
+			query:       ".[0]",
+			expected:    `{"a":1,"b":2}`,
+		},
+		// JSON Input
+		{
+			name:        "JSON array iteration",
+			input:       []byte(`[{"x": 10}, {"x": 20}]`),
+			inputFormat: codec.JSON,
+			query:       ".[] | .x",
+			expected:    "10\n20",
+		},
+		{
+			name:        "JSON length",
+			input:       []byte(`[{"x": 10}, {"x": 20}]`),
+			inputFormat: codec.JSON,
+			query:       "length",
+			expected:    "2",
+		},
+		// YAML Input
+		{
+			name:        "YAML array iteration",
+			input:       []byte("- 100\n- 200\n"),
+			inputFormat: codec.YAML,
+			query:       ".[]",
+			expected:    "100\n200",
+		},
+		// XML Input
+		{
+			name:        "XML field selection",
+			input:       []byte("<root><item>10</item><item>20</item></root>"),
+			inputFormat: codec.XML,
+			query:       ".root.item[]",
+			expected:    "10\n20", // Note:mxj unmarshals elements as string/numbers
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := runPipeline(t, tt.input, tt.inputFormat, codec.JSON, tt.query, false, false)
+			if err != nil {
+				t.Fatalf("pipeline failed: %v", err)
+			}
+			trimmedGot := strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(got), "\n", ""), " ", "")
+			trimmedExp := strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(tt.expected), "\n", ""), " ", "")
+			// For non-JSON output assertions like plain numbers (e.g. 10\n20) we compare directly
+			if !strings.Contains(tt.expected, "{") && !strings.Contains(tt.expected, "[") {
+				trimmedGot = strings.TrimSpace(got)
+				trimmedExp = strings.TrimSpace(tt.expected)
+			}
+			if trimmedGot != trimmedExp {
+				t.Errorf("got: %q, want: %q", trimmedGot, trimmedExp)
+			}
+		})
+	}
+}
+
+
+
+func TestE2E_DisableAutoConvert(t *testing.T) {
+	// 1. CSV Auto-Coercion
+	t.Run("CSV default vs no-auto-convert", func(t *testing.T) {
+		csvInput := []byte("status,count\nT,1\nF,0\ntrue,1.5\n")
+
+		gotDefault, _ := runPipeline(t, csvInput, codec.CSV, codec.JSON, ".[]", false, false)
+		expDefault := `{"count":1,"status":true}{"count":0,"status":false}{"count":1.5,"status":true}`
+		if strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(gotDefault), "\n", ""), " ", "") != expDefault {
+			t.Errorf("default got: %q, want: %q", gotDefault, expDefault)
+		}
+
+		gotDisabled, _ := runPipeline(t, csvInput, codec.CSV, codec.JSON, ".[]", true, false)
+		expDisabled := `{"count":"1","status":"T"}{"count":"0","status":"F"}{"count":"1.5","status":"true"}`
+		if strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(gotDisabled), "\n", ""), " ", "") != expDisabled {
+			t.Errorf("disabled got: %q, want: %q", gotDisabled, expDisabled)
+		}
+	})
+
+	// 2. XML Auto-Coercion
+	t.Run("XML default vs no-auto-convert", func(t *testing.T) {
+		xmlInput := []byte("<root><status>F</status><count>1</count></root>")
+
+		gotDefault, _ := runPipeline(t, xmlInput, codec.XML, codec.JSON, ".", false, false)
+		expDefault := `{"root":{"count":1,"status":false}}`
+		if strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(gotDefault), "\n", ""), " ", "") != expDefault {
+			t.Errorf("default got: %q, want: %q", gotDefault, expDefault)
+		}
+
+		gotDisabled, _ := runPipeline(t, xmlInput, codec.XML, codec.JSON, ".", true, false)
+		expDisabled := `{"root":{"count":"1","status":"F"}}`
+		if strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(gotDisabled), "\n", ""), " ", "") != expDisabled {
+			t.Errorf("disabled got: %q, want: %q", gotDisabled, expDisabled)
+		}
+	})
+
+	// 3. INI Auto-Coercion
+	t.Run("INI default vs no-auto-convert", func(t *testing.T) {
+		iniInput := []byte("[section]\nstatus=F\ncount=1\n")
+
+		gotDefault, _ := runPipeline(t, iniInput, codec.INI, codec.JSON, ".", false, false)
+		expDefault := `{"section":{"count":1,"status":false}}`
+		if strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(gotDefault), "\n", ""), " ", "") != expDefault {
+			t.Errorf("default got: %q, want: %q", gotDefault, expDefault)
+		}
+
+		gotDisabled, _ := runPipeline(t, iniInput, codec.INI, codec.JSON, ".", true, false)
+		expDisabled := `{"section":{"count":"1","status":"F"}}`
+		if strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(gotDisabled), "\n", ""), " ", "") != expDisabled {
+			t.Errorf("disabled got: %q, want: %q", gotDisabled, expDisabled)
+		}
+	})
+
+	// 4. Gron Auto-Coercion
+	t.Run("Gron default vs no-auto-convert", func(t *testing.T) {
+		gronInput := []byte("json.status = \"F\";\njson.count = 1;\n")
+
+		gotDefault, _ := runPipeline(t, gronInput, codec.GRON, codec.JSON, ".json", false, false)
+		expDefault := `{"count":1,"status":false}`
+		if strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(gotDefault), "\n", ""), " ", "") != expDefault {
+			t.Errorf("default got: %q, want: %q", gotDefault, expDefault)
+		}
+
+		gotDisabled, _ := runPipeline(t, gronInput, codec.GRON, codec.JSON, ".json", true, false)
+		expDisabled := `{"count":"1","status":"F"}`
+		if strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(gotDisabled), "\n", ""), " ", "") != expDisabled {
+			t.Errorf("disabled got: %q, want: %q", gotDisabled, expDisabled)
+		}
+	})
+}
+
+func TestE2E_EdgeCases(t *testing.T) {
+	// Unicode and special characters
+	unicodeInput := []byte("name,cél\nJosé,value\n")
+	t.Run("unicode support", func(t *testing.T) {
+		got, err := runPipeline(t, unicodeInput, codec.CSV, codec.JSON, ".", false, false)
+		if err != nil {
+			t.Fatalf("pipeline failed: %v", err)
+		}
+		expected := `[{"cél":"value","name":"José"}]`
+		trimmedGot := strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(got), "\n", ""), " ", "")
+		if trimmedGot != expected {
+			t.Errorf("got: %q, want: %q", trimmedGot, expected)
+		}
+	})
+
+	// Header only (no rows)
+	headerOnlyInput := []byte("a,b,c\n")
+	t.Run("header only", func(t *testing.T) {
+		got, err := runPipeline(t, headerOnlyInput, codec.CSV, codec.JSON, ".", false, false)
+		if err != nil {
+			t.Fatalf("pipeline failed: %v", err)
+		}
+		trimmedGot := strings.TrimSpace(got)
+		if trimmedGot != "null" && trimmedGot != "[]" && trimmedGot != "" {
+			t.Errorf("expected empty/null result, got %q", trimmedGot)
+		}
+	})
+
+	// Empty input for JSON
+	t.Run("empty JSON input", func(t *testing.T) {
+		_, err := runPipeline(t, []byte(""), codec.JSON, codec.JSON, ".", false, false)
+		if err == nil {
+			t.Error("expected error for empty JSON input, got nil")
+		}
+	})
+}

--- a/cli/qq.go
+++ b/cli/qq.go
@@ -25,6 +25,7 @@ func CreateRootCmd() *cobra.Command {
 	var stream bool
 	var slurp bool
 	var exitStatus bool
+	var noAutoConvert bool
 	encodings := strings.Join(codec.GetSupportedExtensions(), ", ")
 	v := "v0.3.4"
 	desc := fmt.Sprintf("qq is a interoperable configuration format transcoder with jq querying ability powered by gojq. qq is multi modal, and can be used as a replacement for jq or be interacted with via a repl with autocomplete and realtime rendering preview for building queries. Supported formats include %s", encodings)
@@ -46,7 +47,7 @@ func CreateRootCmd() *cobra.Command {
 				}
 				os.Exit(0)
 			}
-			handleCommand(cmd, args, inputType, outputType, rawOutput, help, interactive, monochrome, stream, slurp, exitStatus)
+			handleCommand(cmd, args, inputType, outputType, rawOutput, help, interactive, monochrome, stream, slurp, exitStatus, noAutoConvert)
 		},
 	}
 	cmd.Flags().StringVarP(&inputType, "input", "i", "json", "specify input file type, only required on parsing stdin.")
@@ -59,11 +60,13 @@ func CreateRootCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&stream, "stream", false, "parse input in streaming fashion, emitting path-value pairs (supports: json, jsonl, yaml, csv, tsv, line)")
 	cmd.Flags().BoolVarP(&slurp, "slurp", "s", false, "read all inputs into an array and use it as the single input value")
 	cmd.Flags().BoolVarP(&exitStatus, "exit-status", "e", false, "set exit status code based on the output")
+	cmd.Flags().BoolVar(&noAutoConvert, "no-auto-convert", false, "disable automatic type coercion of strings during parsing")
 
 	return cmd
 }
 
-func handleCommand(cmd *cobra.Command, args []string, inputtype string, outputtype string, rawInput bool, help bool, interactive bool, monochrome bool, stream bool, slurp bool, exitStatus bool) {
+func handleCommand(cmd *cobra.Command, args []string, inputtype string, outputtype string, rawInput bool, help bool, interactive bool, monochrome bool, stream bool, slurp bool, exitStatus bool, noAutoConvert bool) {
+	codec.SetDisableAutoConvert(noAutoConvert)
 	var input []byte
 	var err error
 	var expression string

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/goccy/go-json"
 
+	"github.com/JFryy/qq/codec/util"
+
 	// dedicated codec packages and wrappers where appropriate
 	"github.com/JFryy/qq/codec/avro"
 	"github.com/JFryy/qq/codec/base64"
@@ -200,4 +202,8 @@ func Marshal(v any, outputFileType EncodingType) ([]byte, error) {
 
 func IsBinaryFormat(fileType EncodingType) bool {
 	return fileType == PARQUET || fileType == MSGPACK || fileType == CBOR || fileType == AVRO
+}
+
+func SetDisableAutoConvert(disable bool) {
+	util.DisableAutoConvert = disable
 }

--- a/codec/csv/csv.go
+++ b/codec/csv/csv.go
@@ -103,7 +103,7 @@ func (c *Codec) Unmarshal(input []byte, v any) error {
 		return fmt.Errorf("error reading CSV headers: %v", err)
 	}
 
-	var records []map[string]any
+	records := make([]any, 0)
 	for {
 		record, err := r.Read()
 		if err == io.EOF {

--- a/codec/tsv/tsv.go
+++ b/codec/tsv/tsv.go
@@ -80,7 +80,7 @@ func (c *Codec) Unmarshal(input []byte, v any) error {
 		return fmt.Errorf("error reading TSV headers: %v", err)
 	}
 
-	var records []map[string]any
+	records := make([]any, 0)
 	for {
 		record, err := r.Read()
 		if err == io.EOF {

--- a/codec/util/utils.go
+++ b/codec/util/utils.go
@@ -6,7 +6,13 @@ import (
 	"time"
 )
 
+// DisableAutoConvert determines if string values in parser codecs are converted automatically.
+var DisableAutoConvert bool
+
 func ParseValue(value string) any {
+	if DisableAutoConvert {
+		return value
+	}
 	value = strings.TrimSpace(value)
 
 	if intValue, err := strconv.Atoi(value); err == nil {


### PR DESCRIPTION
### Description
This PR adds the `--no-auto-convert` flag to bypass automatic type coercion (like parsing string values `"1"`, `"true"`, `"F"` into floats/booleans) for unstructured flat files (CSV, TSV, XML, INI, Gron, and Text).

### Key Changes
1. **Flag Implementation:** Adds `--no-auto-convert` flag to the root CLI command.
2. **Auto-Coercion Bypass:** Updates `util.ParseValue` in `codec/util/utils.go` to return strings unmodified when `DisableAutoConvert` is enabled.
3. **Empty Input Fix:** Initializes CSV and TSV record slices as empty arrays (`make([]any, 0)`) to prevent returning `null` payloads on header-only inputs.
4. **E2E Tests:** Adds `TestE2E_DisableAutoConvert` in `cli/integration_test.go` checking CSV, XML, INI, and Gron default vs. disabled coercion behavior.

### Justification & Upstream Value
- **Schema Protection:** Auto-detecting types often corrupts values like postal codes (`"90210"` becomes float `90210.0`), phone numbers, or version strings (`"1.10"` becomes `1.1`). This option gives developers strict control over data types.
- **Performance:** Bypassing regex and string checks inside the value parser speeds up parsing on large flat files.

### Verification and Testing
* Ran the E2E tests:
  ```sh
  go test -v ./cli -run TestE2E_DisableAutoConvert
  ```
  *Verifies that strings remain untouched when the flag is enabled.*
```